### PR TITLE
added slack integration tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,11 +101,20 @@ func SendSlackNotification(webhookUrl string, msg string) error {
 		return err
 	}
 
-	buf := new(bytes.Buffer)
-	buf.ReadFrom(resp.Body)
-	if buf.String() != "ok" {
-		return errors.New("Non-ok response returned from Slack")
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if buf.String() != "ok" {
+		return errors.New("non-ok response returned from Slack")
+	}
+
 	return nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
@@ -30,4 +33,78 @@ func TestIsIgnored(t *testing.T) {
 	if !isIgnored(&testProject) {
 		t.Errorf("Project %s is ACCEPTED but it shouldn't", testProject)
 	}
+}
+
+func TestSendSlackNotification(t *testing.T) {
+	const message = "test"
+	const expectedContentType = "application/json"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contentType := r.Header.Get("Content-Type")
+		if contentType != expectedContentType {
+			t.Errorf("expected content type header %s but was %s", expectedContentType, contentType)
+		}
+
+		if r.Method == http.MethodPost {
+			_, err := w.Write([]byte("ok"))
+			if err != nil {
+				t.Error(err)
+			}
+			return
+		}
+
+		var slackReq SlackRequestBody
+		if err := json.NewDecoder(r.Body).Decode(&slackReq); err != nil {
+			t.Error(err)
+		}
+
+		if slackReq.Text != message {
+			t.Errorf("expected message '%s' but was '%s'", message, slackReq.Text)
+		}
+
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+
+	defer srv.Close()
+
+	err := SendSlackNotification(srv.URL, message)
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+func TestSendSlackNotificationFailOnUnexpectedResponse(t *testing.T) {
+	const message = "test"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := w.Write([]byte(""))
+		if err != nil {
+			t.Error(err)
+		}
+	}))
+
+	defer srv.Close()
+
+	err := SendSlackNotification(srv.URL, message)
+	if err == nil {
+		t.Error("an error was expected")
+	}
+
+}
+
+func TestSendSlackNotificationFailOnUnexpectedStatusCode(t *testing.T) {
+	const message = "test"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	defer srv.Close()
+
+	err := SendSlackNotification(srv.URL, message)
+	if err == nil {
+		t.Error("an error was expected")
+	}
+
 }


### PR DESCRIPTION
Fix #2 
This pull request add tests for slack integration using the go lang built in http server.

There are tests for success, unexpected response body and unexpected response code. 

this also fix the error handling for the response reader that was previously ignored and add status code checks for the slack http request. 